### PR TITLE
docs: point README clone instructions to PET repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ SynEval is a comprehensive evaluation framework for assessing the quality of syn
 1. Clone the repository:
 
 ```bash
-git clone https://github.com/SCU-TrustworthyAI/SynEval.git
+git clone https://github.com/privacy-enhancing-technologies/SynEval.git
 cd SynEval
 ```
 


### PR DESCRIPTION
## Summary
- point the README clone instructions to the active privacy-enhancing-technologies/SynEval repository
- previous link went to SCU-TrustworthyAI/SynEval, which no longer contains the CSV files mentioned in the docs

## Testing
- documentation-only change (no automated tests required)