### PR TITLE
Fix: Quote Python versions in CI workflow to prevent YAML parsing as …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10, 3.11, 3.12]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
…floats

Problem
The CI workflow is failing because Python version `3.10` is being parsed as `3.1` by YAML.

Changes
Updated python-version: [3.10, 3.11, 3.12] to python-version: ["3.10", "3.11", "3.12"]